### PR TITLE
Parse list of addresses

### DIFF
--- a/address-parser/README.md
+++ b/address-parser/README.md
@@ -1,0 +1,92 @@
+
+## Prerequisites
+
+Before using the Go bindings, you must install the libpostal C library. Make sure you have the following prerequisites:
+
+**On Ubuntu/Debian**
+```
+sudo apt-get install curl autoconf automake libtool pkg-config
+```
+
+**On CentOS/RHEL**
+```
+sudo yum install curl autoconf automake libtool pkgconfig
+```
+
+**On Mac OSX**
+```
+sudo brew install curl autoconf automake libtool pkg-config
+```
+
+**Installing libpostal**
+
+```bash
+git clone https://github.com/openvenues/libpostal
+cd libpostal
+./bootstrap.sh
+./configure --datadir=[...some dir with a few GB of space...]
+make
+sudo make install
+
+# On Linux it's probably a good idea to run
+sudo ldconfig
+```
+
+**Installing cli tool**
+
+```
+cd services/address-parser
+go install
+```
+
+**Usage**
+
+*Parse from a text file*
+As a file is used a text file separated by '\n'.
+```
+address file <path-to-file>
+```
+
+Example:
+```bash
+address-parser file ~/tmp/addrs.txt
+```
+Result:
+```json
+[
+    {
+        "original": "781 Franklin Ave Crown Heights Brooklyn NY 11216 USA",
+        "parsed": [
+            "781 franklin avenue crown heights brooklyn ny 11216 usa",
+            "781 franklin avenue crown heights brooklyn new york 11216 usa"
+        ]
+    }
+]
+```
+
+
+*Parse from command line*
+```
+address-parser address <query>
+```
+
+Example:
+```bash
+address-parser address "781 Franklin Ave Crown Heights Brooklyn NY 11216 USA"
+```
+Result:
+```json
+[
+    {
+        "original": "781 Franklin Ave Crown Heights Brooklyn NY 11216 USA",
+        "parsed": [
+            "781 franklin avenue crown heights brooklyn ny 11216 usa",
+            "781 franklin avenue crown heights brooklyn new york 11216 usa"
+        ]
+    }
+]
+```
+
+
+
+

--- a/address-parser/main.go
+++ b/address-parser/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	expand "github.com/openvenues/gopostal/expand"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd *cobra.Command
+
+type Item struct {
+	Original string   `json:"original"`
+	Parsed   []string `json:"parsed"`
+}
+
+func getCommands() map[string]*cobra.Command {
+	return map[string]*cobra.Command{
+		"file": {
+			Use:     "file",
+			Short:   "",
+			Example: "address-parser file <path-to-file>",
+			Args:    cobra.MinimumNArgs(1),
+			Run: func(cmd *cobra.Command, args []string) {
+				processFromFile(args[0])
+			},
+		},
+		"address": {
+			Use:     "address",
+			Short:   "",
+			Example: "address-parser address <address-string>",
+			Args:    cobra.MinimumNArgs(1),
+			Run: func(cmd *cobra.Command, args []string) {
+				processFromAddress(args[0])
+			},
+		},
+	}
+}
+
+func init() {
+	rootCmd = &cobra.Command{Use: "address-parser"}
+	for _, command := range getCommands() {
+		rootCmd.AddCommand(command)
+	}
+}
+
+func processFromAddress(addr string) {
+	var items = make([]*Item, 0)
+	expansions := expand.ExpandAddress(addr)
+	item := &Item{
+		Original: addr,
+		Parsed:   expansions,
+	}
+	items = append(items, item)
+	result, err := json.MarshalIndent(&items, "", "    ")
+	if err != nil {
+		fmt.Printf("failed get address. err: %v\n", err.Error())
+	}
+	fmt.Println(string(result))
+}
+
+func processFromFile(path string) {
+	file, err := os.Open(path)
+	if err != nil {
+		fmt.Printf("failed open file: %v. err: %v\n", path, err.Error())
+		return
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	var items = make([]*Item, 0)
+
+	for scanner.Scan() {
+		addr := scanner.Text()
+		if addr != "" {
+			expansions := expand.ExpandAddress(addr)
+			item := &Item{
+				Original: addr,
+				Parsed:   expansions,
+			}
+			items = append(items, item)
+		}
+	}
+	result, err := json.MarshalIndent(&items, "", "    ")
+	if err != nil {
+		fmt.Printf("failed get address. err: %v\n", err.Error())
+		return
+	}
+	fmt.Println(string(result))
+}
+
+func main() {
+	rootCmd.Execute()
+}


### PR DESCRIPTION
#92 

**Usage**

*Parse from a text file*
As a file is used a text file separated by '\n'.
```
address file <path-to-file>
```

Example:
```bash
address-parser file ~/tmp/addrs.txt
```
Result:
```json
[
    {
        "original": "781 Franklin Ave Crown Heights Brooklyn NY 11216 USA",
        "parsed": [
            "781 franklin avenue crown heights brooklyn ny 11216 usa",
            "781 franklin avenue crown heights brooklyn new york 11216 usa"
        ]
    },
    {
        "original": "23 ulitsa Ilyinka 103132 Moscow Russia",
        "parsed": [
            "23 ulitsa ilyinka 103132 moscow russia"
        ]
    }
]```


*Parse from command line*
```
address-parser address <query>
```

Example:
```bash
address-parser address "781 Franklin Ave Crown Heights Brooklyn NY 11216 USA"
```
Result:
```json
[
    {
        "original": "781 Franklin Ave Crown Heights Brooklyn NY 11216 USA",
        "parsed": [
            "781 franklin avenue crown heights brooklyn ny 11216 usa",
            "781 franklin avenue crown heights brooklyn new york 11216 usa"
        ]
    }
]
```