### PR TITLE
added naive checker, script and configuration to update skywire

### DIFF
--- a/autoupdater/README.md
+++ b/autoupdater/README.md
@@ -9,7 +9,7 @@ available, update them.
 
 Autoupdater allows to configure:
 
-    1. How to look for updates: Currently support to perform periodical checks on github or dockerhub (we call this active update checkers), or to subscribe to a publisher that will send autoupdater update notifications (we call this passive update checkers), the only publisher supported so far is [nats](https://nats.io/).
+    1. How to look for updates: Currently support to perform periodical checks on github or dockerhub (we call this active update checkers), there is also a naive active checker that will just call the updater every interval, or to subscribe to a publisher that will send autoupdater update notifications (we call this passive update checkers), the only publisher supported so far is [nats](https://nats.io/).
     
     2. How to update services: We call this Updaters, and currently there are supported docker swarm and custom scripts.
     

--- a/autoupdater/configuration.skywire.yml
+++ b/autoupdater/configuration.skywire.yml
@@ -1,0 +1,39 @@
+active_update_checkers:
+  naive:
+    interval: "30s"
+    retries: 3
+    retry_time: "22s"
+    kind: "naive"
+
+updaters:
+  custom:
+    kind: "custom"
+
+services:
+  skywire-manager:
+    official_name: "skywire-manager"
+    local_name: "manager"
+    update_script: "/Users/ivan/Desktop/skycoin/src/github.com/skycoin/services/autoupdater/src/updater/scripts/skywire.sh"
+    script_interpreter: "/bin/bash"
+    script_timeout: "20m"
+    script_extra_arguments:
+      - "-web-dir ${GOPATH}/src/github.com/skycoin/skywire/static/skywire-manager"
+    active_update_checker: "naive"
+    repository: "/skycoin/skywire"
+    updater: "custom"
+
+  skywire-node:
+    official_name: "skywire-node"
+    local_name: "node"
+    update_script: "/Users/ivan/Desktop/skycoin/src/github.com/skycoin/services/autoupdater/src/updater/scripts/skywire.sh"
+    script_interpreter: "/bin/bash"
+    script_timeout: "20m"
+    script_extra_arguments:
+      - "-connect-manager -manager-address 127.0.0.1:5998"
+      - "-manager-web 127.0.0.1:8000"
+      - "-discovery-address discovery.skycoin.net:5999-034b1cd4ebad163e457fb805b3ba43779958bba49f2c5e1e8b062482904bacdb68"
+      - "-address :5000"
+      - "-web-port :6001"
+    active_update_checker: "naive"
+    repository: "/skycoin/skywire"
+    updater: "custom"

--- a/autoupdater/src/active/fetcher.go
+++ b/autoupdater/src/active/fetcher.go
@@ -33,6 +33,9 @@ func New(service string, c *config.Configuration, updater updater.Updater, log *
 	case "git":
 		return newGit(updater, service, serviceConfig.Repository, updateCheckerConfig.Retries,
 			retryTime, log)
+	case "naive":
+		return newNaive(updater, service, serviceConfig.Repository, updateCheckerConfig.Retries,
+			retryTime, log)
 	case "dockerhub":
 		return newDockerHub(updater, serviceConfig.Repository, serviceConfig.CheckTag,
 			serviceConfig.OfficialName, "", log)

--- a/autoupdater/src/active/naive.go
+++ b/autoupdater/src/active/naive.go
@@ -1,0 +1,106 @@
+package active
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/services/autoupdater/config"
+	"github.com/skycoin/services/autoupdater/src/logger"
+	"github.com/skycoin/services/autoupdater/src/updater"
+)
+
+type naive struct {
+	// Url should be in the format /:owner/:Repository
+	service   string
+	url string
+	interval  time.Duration
+	ticker    *time.Ticker
+	lock      sync.Mutex
+	updater   updater.Updater
+	exit      chan int
+	retryTime time.Duration
+	retries   int
+	log *logger.Logger
+	config.CustomLock
+}
+
+func newNaive(u updater.Updater, service, url string, retries int, retryTime time.Duration, log *logger.Logger) *naive{
+	return &naive{
+		url:       "github.com" + url,
+		exit:      make(chan int),
+		updater:   u,
+		service:   service,
+		retries:   retries,
+		retryTime: retryTime,
+		log: log,
+	}
+}
+
+func (n *naive) SetInterval(t time.Duration) {
+	n.interval = t
+
+	n.lock.Lock()
+	if n.ticker != nil {
+		n.ticker = time.NewTicker(n.interval)
+	}
+	n.lock.Unlock()
+}
+
+
+func (n *naive) Start() {
+	n.ticker = time.NewTicker(n.interval)
+	go func() {
+		for {
+			select {
+			case t := <-n.ticker.C:
+				n.log.Info("looking for new version at: ", t)
+				// Try to fetch new version
+				go n.checkIfNew()
+			}
+		}
+	}()
+	<-n.exit
+}
+
+func (n *naive) Stop() {
+	n.ticker.Stop()
+	n.exit <- 1
+}
+
+func (n *naive) checkIfNew() {
+	if n.IsLock() {
+		n.log.Warnf("service %s is already being updated... waiting for it to finish", n.service)
+	}
+	n.Lock()
+	defer n.Unlock()
+
+	n.log.Info("updating...")
+		err := n.tryUpdate()
+
+		if err != nil {
+			logrus.Error(err)
+		}
+}
+
+func (n *naive) tryUpdate() error {
+	for i := 0; i < n.retries; i++ {
+		err := <-n.updater.Update(n.service, n.service, n.log)
+		if err != nil {
+			n.log.Errorf("error on update %s", err)
+
+			if i == (n.retries - 1) {
+				return fmt.Errorf("maximum retries attempted, service %s failed to update", n.service)
+			} else {
+				n.log.Infof("retry again in %s", n.retryTime.String())
+			}
+		} else {
+			break
+		}
+
+		time.Sleep(n.retryTime)
+	}
+	return nil
+}

--- a/autoupdater/src/updater/scripts/skywire.sh
+++ b/autoupdater/src/updater/scripts/skywire.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# We hardcode the service and just care about the version
+process_name=$1
+version=$2
+shift 2
+arguments=$@
+parsed_args=$(eval echo ${arguments})
+
+echo "process name: ${process_name}"
+
+binary="${GOPATH}/src/github.com/skycoin/skywire/cmd/${process_name}"
+
+socksc_binary="${GOPATH}/src/github.com/skycoin/skywire/cmd/socks/socksc"
+sockss_binary="${GOPATH}/src/github.com/skycoin/skywire/cmd/socks/sockss"
+sshc_binary="${GOPATH}/src/github.com/skycoin/skywire/cmd/ssh/sshc"
+sshs_binary="${GOPATH}/src/github.com/skycoin/skywire/cmd/ssh/sshs"
+
+service_github_url="github.com/skycoin/skywire"
+binary_directory=${GOBIN}
+
+build_and_copy_if_different () {
+    cd $1
+    go build
+
+    if [[ -z $(diff ${GOBIN}/${2} ./${2}) ]]; then
+        echo "already up to date"
+        exit 0
+    fi
+
+    cp ${2} ${GOBIN}/${2}
+}
+
+build_and_copy () {
+    cd $1
+    go build
+
+    cp ${2} ${GOBIN}/${2}
+}
+
+echo "fetching"
+echo "go get -d -u ${service_github_url}"
+
+# fetch new version
+go get -d -u ${service_github_url}
+exit_status=$?
+
+if [ ${exit_status} != 0 -a ${exit_status} != 1 ]; then
+    exit 1
+fi
+
+echo "fetched"
+
+echo "updating..."
+
+build_and_copy ${socksc_binary} "socksc"
+build_and_copy ${sockss_binary} "sockss"
+build_and_copy ${sshc_binary} "sshc"
+build_and_copy ${sshs_binary} "sshs"
+
+build_and_copy_if_different ${binary} ${process_name}
+
+echo "updated"
+echo "restarting..."
+
+cd ${GOBIN}
+pkill -9 -F ${process_name}.pid
+
+if [ ${process_name} == "manager" ]; then
+    echo ${parsed_args}
+    #nohup ./manager ${arguments} > /dev/null 2>&1 &sleep 3
+    nohup ./manager ${parsed_args} > ${process_name}.log 2>&1 &echo $! > ${process_name}.pid &sleep 3
+else
+    #nohup ./node ${arguments} > /dev/null 2>&1 &sleep 3
+    nohup ./node ${parsed_args} > ${process_name}.log 2>&1 &echo $! > ${process_name}.pid &sleep 3
+fi


### PR DESCRIPTION
This PR implements a naive checker that will perform an update every interval, there is also implemented a script to use go get to update skywire and relaunch the processes.

There is a configuration file that sets autoupdater to use update skywire, both manager and nodes.